### PR TITLE
Fix some broken external links in request-access-to-tools.md. There are more.

### DIFF
--- a/Onboarding/request-access-to-tools.md
+++ b/Onboarding/request-access-to-tools.md
@@ -53,7 +53,7 @@ To work on the Veteran-facing Services Platform, each team member needs to reque
 
 ## Additional onboarding steps for developers
 
-#### 1. Create [new SSH keys](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Work%20Practices/Engineering/Internal%20Tools.md#create-an-ssh-public-key).
+#### 1. Create [new SSH keys](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Practice%20Areas/Engineering/Internal%20Tools.md#create-an-ssh-public-key).
 
 #### 2. Request that your SSH keys be authorized so that you can use the developer tools.
 * File an issue in [vets.gov-team repo](https://github.com/department-of-veterans-affairs/vets.gov-team).
@@ -67,8 +67,8 @@ To work on the Veteran-facing Services Platform, each team member needs to reque
 
 #### 3. When your key has been added, DSVA will close the Github issue, which will send a Github notification to you. This is your signal that you can continue to the next step.
 
-#### 4. Configure [the SOCKS proxy](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Work%20Practices/Engineering/Internal%20Tools.md#configure-the-socks-proxy---all-other-developers).
+#### 4. Configure [the SOCKS proxy](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Practice%20Areas/Engineering/Internal%20Tools.md#configure-the-socks-proxy---all-other-developers).
 
-#### 5. Understand [how to use the SOCKS proxy from inside the VA network and from the internet](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Work%20Practices/Engineering/Internal%20Tools.md#accessing-socks-proxy-from-va-network).
+#### 5. Understand [how to use the SOCKS proxy from inside the VA network and from the internet](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Practice%20Areas/Engineering/Internal%20Tools.md#accessing-socks-proxy-from-va-network).
 
-#### 6. [Test and use the SOCKS proxy](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Work%20Practices/Engineering/Internal%20Tools.md#testing-and-using-the-socks-proxy).
+#### 6. [Test and use the SOCKS proxy](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Practice%20Areas/Engineering/Internal%20Tools.md#testing-and-using-the-socks-proxy).


### PR DESCRIPTION
The PR https://github.com/department-of-veterans-affairs/vets.gov-team/pull/18380 caused a large amount of links to break. This is just one document of the breakage, a find/replace is not easy because some files went to different folders.